### PR TITLE
fix: go-libdht version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/multiformats/go-multiaddr v0.11.0
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/probe-lab/go-libdht v0.1.0
+	github.com/probe-lab/go-libdht v0.1.1
 	github.com/prometheus/client_golang v1.16.0 // indirect
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/otel v1.18.0

--- a/go.sum
+++ b/go.sum
@@ -271,12 +271,12 @@ github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhM
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/probe-lab/go-libdht v0.1.0 h1:lcysqaU3hVg2f8I5hZT7XdoPERkrI3HrH5x59LBm7GA=
-github.com/probe-lab/go-libdht v0.1.0/go.mod h1:1m6gBp1WX7RPN3KnwC5BX5YZ5nDTy+g6x9M4fgb/n1w=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/polydawn/refmt v0.89.0 h1:ADJTApkvkeBZsN0tBTx8QjpD9JkmxbKp0cxfr9qszm4=
 github.com/polydawn/refmt v0.89.0/go.mod h1:/zvteZs/GwLtCgZ4BL6CBsk9IKIlexP43ObX9AxTqTw=
+github.com/probe-lab/go-libdht v0.1.1 h1:b6R4cr2Z6PKKzAgXv7y7Rgp9ajaF/Sn17vF8mQYN8xA=
+github.com/probe-lab/go-libdht v0.1.1/go.mod h1:DtQ0H+YdJQlBiyayohV8fKusnjqk88+yuwDKltan8ks=
 github.com/prometheus/client_golang v0.8.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.16.0 h1:yk/hx9hDbrGHovbci4BY+pRMfSuuat626eFsHb7tmT8=
 github.com/prometheus/client_golang v1.16.0/go.mod h1:Zsulrv/L9oM40tJ7T815tM89lFEugiJ9HzIqaAx4LKc=


### PR DESCRIPTION
Update [go-libdht](https://github.com/probe-lab/go-libdht) version in dependencies to match the last version reflecting the Github org name change